### PR TITLE
Fix min_refresh_interval() side effect

### DIFF
--- a/src/netinfo/packet_matcher.rs
+++ b/src/netinfo/packet_matcher.rs
@@ -72,17 +72,18 @@ impl PacketMatcher {
     }
 
     /// This function updates the tables that are used for the matching.
-    fn refresh(&mut self) -> Result<()> {
+    /// Returns false if refresh was skipped due to `min_refresh_interval`
+    fn refresh(&mut self) -> Result<bool> {
         if let Some(min_refresh_interval) = self.min_refresh_interval {
             let now = Instant::now();
             if let Some(last_refresh) = self.last_refresh {
-                if now - last_refresh < min_refresh_interval { return Ok(()); }
+                if now - last_refresh < min_refresh_interval { return Ok((false)); }
             }
             self.last_refresh = Some(now);
         }
         self.tables.refresh()?;
         self.update_known_connections()?;
-        Ok(())
+        Ok((true))
     }
 
     /// A process might end a connection and another might open the same connection.
@@ -134,12 +135,14 @@ impl PacketMatcher {
         if let Some(&res) = self.known_connections.get(&(tt, c)) {
             // Known connection! Does this connection have a process?
             Ok(res.map(|(_, pid)| pid))
-        } else {
-            // Unknown connection!
-            self.refresh()?;
+        } else if self.refresh()? {
+             // Unknown connection! But refresh was succesful
             let inode_pid_opt = self.tables.map_connection(tt, c);
             self.known_connections.insert((tt, c), inode_pid_opt);
             Ok(inode_pid_opt.map(|(_, pid)| pid))
+        } else { // Unknown connection and refresh was skipped
+            // we simply return None and will retry to find the PID after a succesful refresh
+            Ok(None)
         }
     }
 


### PR DESCRIPTION
When `PacketMatcher` cannot find a PID associated to a connection, it refreshes its mapping tables and then tries to find the connection's PID, which will be bound to the connection until the connection is dropped.

But there is a scenario which causes a connection's packets to never be assigned to a process:

1. A `min_refresh_interval` is set, to let's say 20ms
2. A packet is captured from a new connection:
   a. `refresh()` is called, updating the connection / inode / PID mapping tables
   b. These tables are used to retrieve the PID associated to the connection
3. A second creation is created a few ms after the first one and a packet from this connection is captured
  a. `refresh()` is called, but because of the `min_refresh_interval`, the mapping tables are not updated
  b. The mapping tables only contains data known at the step 2.b, and do not include this new connection. 
  c. The return value of `self.tables.map_connection()`, in this case `None`, is assigned to the connection

From now on, all captured packets from this connection will never be assigned to a process.

To fix this behavior, I propose to attempt a `refresh()` in `find_pid_cached()`, when no PID is assigned to the connection. `refresh()` will then call `update_known_connection()` which will try to assign a PID from the updated mapping tables.
